### PR TITLE
Avoid undefined $basePath exception

### DIFF
--- a/src/Webcreate/Vcs/Svn/AbstractSvn.php
+++ b/src/Webcreate/Vcs/Svn/AbstractSvn.php
@@ -215,7 +215,7 @@ abstract class AbstractSvn extends AbstractClient
         }
 
         $retval = $this->url;
-        if ($basePath) {
+        if (isset($basePath)) {
             $retval.= '/' . $basePath;
         }
 


### PR DESCRIPTION
Without this patch, `$basePath` may sometimes not get set and trigger an undefined variable exception.
